### PR TITLE
Bug fixes (docker-compose up)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ lucida_services:
   ports:
     - "8081:8081" # learn server
     - "8090:8090" # cc
-  command: bash -c "cd tools && supervisord -c full_lucida.conf"
+  command: bash -c "supervisord -c supervisord.conf"
 
 lucida_asr:
   image: claritylab/lucida-asr:latest


### PR DESCRIPTION
Command used for this bug:
$docker pull claritylab/lucida:latest
$docker pull claritylab/lucida-asr
$docker-compose up

Distribution Used: manjaro kde with kernel 4.13

Packages installed: 
    docker-compose (Pacman Repo)
    docker (Pacman Repo)
    docker-machine (Pacman Repo)

Error:
------------------BEGIN--------------------
lucida_lucida_asr_1  Cannot start service lucida_asr: b'Cannot link to a non running container: /lucida_lucida_services_1 AS /lucida_lucida_asr_1/lucida_lucida_services_1' 
--------------------END----------------------
because the tools folder not exist

logs of claritylab/lucida:latest : 
------------------BEGIN--------------------
bash: cd: tools: No such file or directory
--------------------END----------------------